### PR TITLE
Update state-badge.html

### DIFF
--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -21,6 +21,7 @@
 
   iron-image {
     border-radius: 50%;
+    background-color: #FFFFFF;
   }
 
   ha-state-icon {


### PR DESCRIPTION
RE: #19, added a background-color to the icon-image in this element fixes the issue where images and icons overlap but allows a fallback if an image is not defined.  The only situation that this doesn't cover is if an icon is specified and the link is broken (i.e. a 404 on the image), then there will just be a white block. I decided this was actually more useful since then its really obvious that there should be an image there and I should fix the link.